### PR TITLE
Handle nonexisting uids

### DIFF
--- a/lib/duduckdb/duduckdb.py
+++ b/lib/duduckdb/duduckdb.py
@@ -168,7 +168,11 @@ class DUDB(object):
                             newer_than=newer_than, uid=uid,
                             timestamp_type=timestamp_type
                         )
-                        username = pwd.getpwuid(uid).pw_name
+                        try:
+                            username = pwd.getpwuid(uid).pw_name
+                        except KeyError:
+                            logging.warning(f'Failed to look up uid {uid}')
+                            username = str(uid)
                         results.append([basedir, username, depth] + sizes)
         if not suppress_output:
             suffixes = ["" if m == "inodes" else "B" for m in metrics]


### PR DESCRIPTION
There are a few cases (for instance staging 80) where duduckdb fails with `--per-user` because some files have a uid that is not known on the system. It is of course weird that such files without a proper owner exist, but I think this PR handles is sufficiently well (i.e. print a warning and work with the uid instead of the username).

## The error message before fixing:
```
$ duduckdb stg_00080.parquet --human-readable --per-user --max-depth=0
File "/apps/leuven/rocky8/cascadelake/2024a/software/duduckdb/1.0-GCC-13.3.0/lib/python3.12/site-packages/duduckdb/duduckdb.py", line 171, in report_du
username = pwd.getpwuid(uid).pw_name
```

## After fixing:

```
$ duduckdb stg_00080.parquet --human-readable --per-user --max-depth=0
...
WARNING:root:Failed to look up uid 2549205605
WARNING:root:Failed to look up uid 2549205603
...
    2549205603:          12.0KiB          3.0
...
```