### PR TITLE
Interpret empty query result as size 0

### DIFF
--- a/lib/duduckdb/duduckdb.py
+++ b/lib/duduckdb/duduckdb.py
@@ -307,5 +307,9 @@ class DUDB(object):
 
             # Get value
             self.conn.execute(query)
-            sizes.append(self.conn.fetchone()[0])
+            result = self.conn.fetchone()[0]
+            # When nothing is found, this should be interpreted as 0
+            if result is None:
+                result = 0
+            sizes.append(result)
         return sizes


### PR DESCRIPTION
A user reported following error:

```
directory:               size             inodes
================================================================================
Traceback (most recent call last):
  File "/apps/leuven/rocky8/skylake/2024a/software/duduckdb/1.0-GCC-13.3.0/bin/duduckdb", line 119, in <module>
    db.report_du(top_directory=args.top_directory, per_user=args.per_user,
  File "/apps/leuven/rocky8/skylake/2024a/software/duduckdb/1.0-GCC-13.3.0/lib/python3.12/site-packages/duduckdb/duduckdb.py", line 195, in report_du
    results = self.sort_list(results, columns, sort_by)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/apps/leuven/rocky8/skylake/2024a/software/duduckdb/1.0-GCC-13.3.0/lib/python3.12/site-packages/duduckdb/duduckdb.py", line 280, in sort_list
    sorted_list = sorted(results, key=sorter.sort)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/apps/leuven/rocky8/skylake/2024a/software/duduckdb/1.0-GCC-13.3.0/lib/python3.12/site-packages/duduckdb/duduckdb.py", line 269, in __lt__
    return other.obj < self.obj  # Reversed comparison logic
           ^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

This happens because when a query returns no files, the size was interpreted as `None`. The correct behavior is to interpret that as being a zero value, which is implemented in this PR.